### PR TITLE
Fix yakafokon: simplification de la regex et correction du cas "ça serait bien"

### DIFF
--- a/src/alain/alain3.py
+++ b/src/alain/alain3.py
@@ -42,7 +42,7 @@ class Alain:
 
     @irc3.event(
         r":(?P<mask>\S+) PRIVMSG {channel} :"
-        r".*(faudrai.|faut|[scç]a serai. bien)\s+qu.*"
+        r".*(faudrai.|faut|[scç]a serai.? bien)\s+qu.*"
     )
     def yakafokon(self, mask=None, channel=None, data=None):
         message = "WARNING !!! YAKAFOKON DETECTED !!!!"

--- a/src/alain/alain3.py
+++ b/src/alain/alain3.py
@@ -42,7 +42,7 @@ class Alain:
 
     @irc3.event(
         r":(?P<mask>\S+) PRIVMSG {channel} :"
-        r".*\s(faudrai.|faut|ca serait bien que)\s+qu.*"
+        r".*(faudrai.|faut|[scç]a serai. bien)\s+qu.*"
     )
     def yakafokon(self, mask=None, channel=None, data=None):
         message = "WARNING !!! YAKAFOKON DETECTED !!!!"


### PR DESCRIPTION
Correction d'une erreur dans la regex qui invalidait le cas du "ça serait bien que".

Test des différents cas pris en charge (ou volontairement écartés) sur Regex101 : 

![Capture d’écran Regex101](https://user-images.githubusercontent.com/7600265/222529950-08e41118-b64a-4f4c-b78a-11f875364a42.png)
